### PR TITLE
add target dependency for nrf51dk

### DIFF
--- a/module.json
+++ b/module.json
@@ -41,6 +41,9 @@
     },
     "mkit": {
       "mbed-hal-mkit": "~0.0.1"
+    },
+    "nrf51dk": {
+      "mbed-hal-nrf51dk" : "~0.0.1"
     }
   }
 }


### PR DESCRIPTION
We'd like to make the nRF51-DK one of the supported platforms.

CR @0xc0170 
