### PR TITLE
add the extra step of linking PLATFORM_SPECIFIC_HAL_LIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ elseif(TARGET_LIKE_MKIT)
     set(PLATFORM_SPECIFIC_HAL_LIB mbed-hal-mkit)
 elseif(TARGET_LIKE_NRF51DK)
     set(PLATFORM_SPECIFIC_HAL_LIB mbed-hal-nrf51dk)
+else()
+    message(FATAL_ERROR "Missing PLATFORM_SPECIFIC_HAL_LIB")
 endif()
 
 target_link_libraries(mbed-hal-nrf51822-mcu


### PR DESCRIPTION
@0xc0170 @autopulated 

ble-examples currently don't build because mbed_hal_init() [in init_api.c] doesn't get added to the linker command. @PrzemekWirkus  is blocked on this as he integrates test automation for BLE. A quick review would be helpful. thanks.
