### PR TITLE
updating dependency for mbed-hal-nordic to ^2.0.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
     "mbed-hal-nrf51822-mcu/lib/nordic_sdk/components/libraries/crc16"
   ],
   "dependencies": {
-    "mbed-hal-nordic": "^1.0.0",
+    "mbed-hal-nordic": "^2.0.0",
     "cmsis-core": "^1.0.0",
     "ble-nrf51822": "^2.0.0"
   },

--- a/module.json
+++ b/module.json
@@ -28,7 +28,7 @@
     "mbed-hal-nrf51822-mcu/lib/nordic_sdk/components/libraries/crc16"
   ],
   "dependencies": {
-    "mbed-hal-nordic": "^2.0.0",
+    "mbed-hal": "^1.0.0",
     "cmsis-core": "^1.0.0",
     "ble-nrf51822": "^2.0.0"
   },


### PR DESCRIPTION
@0xc0170 

and the ripple effect continues.