### PR TITLE
Add ifdefs to reduce include warnings in mbed OS

### DIFF
--- a/mbed-hal-nrf51822-mcu/gpio_object.h
+++ b/mbed-hal-nrf51822-mcu/gpio_object.h
@@ -16,7 +16,11 @@
 #ifndef MBED_GPIO_OBJECT_H
 #define MBED_GPIO_OBJECT_H
 
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+#else
+    #include "mbed_assert.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/source/analogin_api.c
+++ b/source/analogin_api.c
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+#else
+    #include "mbed_assert.h"
+#endif
+
 #include "analogin_api.h"
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/gpio_api.c
+++ b/source/gpio_api.c
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+#else
+    #include "mbed_assert.h"
+#endif
 #include "gpio_api.h"
 #include "pinmap.h"
 

--- a/source/gpio_irq_api.c
+++ b/source/gpio_irq_api.c
@@ -17,7 +17,12 @@
 #include "cmsis.h"
 
 #include "gpio_irq_api.h"
-#include "mbed_error.h"
+
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_error.h"
+#else
+    #include "mbed_error.h"
+#endif
 
 #define CHANNEL_NUM    31
 

--- a/source/i2c_api.c
+++ b/source/i2c_api.c
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+    #include "mbed-drivers/mbed_error.h"
+#else
+    #include "mbed_assert.h"
+    #include "mbed_error.h"
+#endif
+
 #include "i2c_api.h"
 #include "cmsis.h"
 #include "pinmap.h"
-#include "mbed_error.h"
 
 // nRF51822's I2C_0 and SPI_0 (I2C_1, SPI_1 and SPIS1) share the same address.
 // They can't be used at the same time. So we use two global variable to track the usage.

--- a/source/pinmap.c
+++ b/source/pinmap.c
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+    #include "mbed-drivers/mbed_error.h"
+#else
+    #include "mbed_assert.h"
+    #include "mbed_error.h"
+#endif
+
 #include "pinmap.h"
-#include "mbed_error.h"
 
 void pin_function(PinName pin, int function)
 {

--- a/source/pwmout_api.c
+++ b/source/pwmout_api.c
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+    #include "mbed-drivers/mbed_error.h"
+#else
+    #include "mbed_assert.h"
+    #include "mbed_error.h"
+#endif
+
 #include "pwmout_api.h"
 #include "cmsis.h"
 #include "pinmap.h"
-#include "mbed_error.h"
 
 #define NO_PWMS         3
 #define TIMER_PRECISION 4 //4us ticks

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -16,7 +16,12 @@
 // math.h required for floating point operations for baud rate calculation
 //#include <math.h>
 #include <string.h>
-#include "mbed_assert.h"
+
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+#else
+    #include "mbed_assert.h"
+#endif
 
 #include "serial_api.h"
 #include "cmsis.h"

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 //#include <math.h>
-#include "mbed_assert.h"
+#ifdef YOTTA_CFG_MBED_OS
+    #include "mbed-drivers/mbed_assert.h"
+    #include "mbed-drivers/mbed_error.h"
+#else
+    #include "mbed_assert.h"
+    #include "mbed_error.h"
+#endif
+
 #include "spi_api.h"
 #include "cmsis.h"
 #include "pinmap.h"
-#include "mbed_error.h"
 
 #define SPIS_MESSAGE_SIZE 1
 volatile uint8_t m_tx_buf[SPIS_MESSAGE_SIZE] = {0};


### PR DESCRIPTION
The build process prints large amounts of warnings because when using mbed OS the files mbed.h, mbed_assert.h and mbed_error.h are included when the correct include paths should be "mbed-drivers/mbed.h". To solve the problem ifdefs are introduced to check whether YOTTA_CFG_MBED_OS is defined and use the correct include.