### PR TITLE
Remove ifdefs checking for mbedOS for includes

### DIFF
--- a/mbed-hal-nrf51822-mcu/gpio_object.h
+++ b/mbed-hal-nrf51822-mcu/gpio_object.h
@@ -16,11 +16,7 @@
 #ifndef MBED_GPIO_OBJECT_H
 #define MBED_GPIO_OBJECT_H
 
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-#else
-    #include "mbed_assert.h"
-#endif
+#include "mbed-drivers/mbed_assert.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/source/analogin_api.c
+++ b/source/analogin_api.c
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-#else
-    #include "mbed_assert.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
 #include "analogin_api.h"
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/gpio_api.c
+++ b/source/gpio_api.c
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-#else
-    #include "mbed_assert.h"
-#endif
+#include "mbed-drivers/mbed_assert.h"
 #include "gpio_api.h"
 #include "pinmap.h"
 

--- a/source/gpio_irq_api.c
+++ b/source/gpio_irq_api.c
@@ -17,12 +17,7 @@
 #include "cmsis.h"
 
 #include "gpio_irq_api.h"
-
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_error.h"
-#else
-    #include "mbed_error.h"
-#endif
+#include "mbed-drivers/mbed_error.h"
 
 #define CHANNEL_NUM    31
 

--- a/source/i2c_api.c
+++ b/source/i2c_api.c
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-    #include "mbed-drivers/mbed_error.h"
-#else
-    #include "mbed_assert.h"
-    #include "mbed_error.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-drivers/mbed_error.h"
 #include "i2c_api.h"
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/pinmap.c
+++ b/source/pinmap.c
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-    #include "mbed-drivers/mbed_error.h"
-#else
-    #include "mbed_assert.h"
-    #include "mbed_error.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-drivers/mbed_error.h"
 #include "pinmap.h"
 
 void pin_function(PinName pin, int function)

--- a/source/pwmout_api.c
+++ b/source/pwmout_api.c
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-    #include "mbed-drivers/mbed_error.h"
-#else
-    #include "mbed_assert.h"
-    #include "mbed_error.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-drivers/mbed_error.h"
 #include "pwmout_api.h"
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -17,12 +17,7 @@
 //#include <math.h>
 #include <string.h>
 
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-#else
-    #include "mbed_assert.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
 #include "serial_api.h"
 #include "cmsis.h"
 #include "pinmap.h"

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 //#include <math.h>
-#ifdef YOTTA_CFG_MBED_OS
-    #include "mbed-drivers/mbed_assert.h"
-    #include "mbed-drivers/mbed_error.h"
-#else
-    #include "mbed_assert.h"
-    #include "mbed_error.h"
-#endif
-
+#include "mbed-drivers/mbed_assert.h"
+#include "mbed-drivers/mbed_error.h"
 #include "spi_api.h"
 #include "cmsis.h"
 #include "pinmap.h"


### PR DESCRIPTION
Removed the ifdefs introduced earlier checking whether YOTTA_CFG_MBED_OS is defined to include either "mbed.h" or "mbed-drivers/mbed.h" to reduce warnings. It was found that compatibility with mbed classic is not needed for this module.
@rgrover 