### PR TITLE
Clean up code to reduce warnings and whitespaces

### DIFF
--- a/source/i2c_api.c
+++ b/source/i2c_api.c
@@ -53,8 +53,9 @@ void twi_master_init(i2c_t *obj, PinName sda, PinName scl, int frequency)
 
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
-    NRF_TWI_Type *i2c;
-  
+    // Initialize variable to avoid compiler warnings
+    NRF_TWI_Type *i2c = (NRF_TWI_Type *)I2C_0;
+
     if (i2c0_spi0_peripheral.usage == I2C_SPI_PERIPHERAL_FOR_I2C &&
             i2c0_spi0_peripheral.sda_mosi == (uint8_t)sda &&
             i2c0_spi0_peripheral.scl_miso == (uint8_t)scl) {
@@ -71,14 +72,14 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
         i2c0_spi0_peripheral.usage = I2C_SPI_PERIPHERAL_FOR_I2C;
         i2c0_spi0_peripheral.sda_mosi = (uint8_t)sda;
         i2c0_spi0_peripheral.scl_miso = (uint8_t)scl;
-        
+
         i2c = (NRF_TWI_Type *)I2C_0;
         obj->peripheral = 0x1;
     } else if (i2c1_spi1_peripheral.usage == 0) {
         i2c1_spi1_peripheral.usage = I2C_SPI_PERIPHERAL_FOR_I2C;
         i2c1_spi1_peripheral.sda_mosi = (uint8_t)sda;
         i2c1_spi1_peripheral.scl_miso = (uint8_t)scl;
-        
+
         i2c = (NRF_TWI_Type *)I2C_1;
         obj->peripheral = 0x2;
     } else {

--- a/source/pinmap.c
+++ b/source/pinmap.c
@@ -19,6 +19,9 @@
 
 void pin_function(PinName pin, int function)
 {
+    /* Avoid compiler warnings */
+    (void) pin;
+    (void) function;
 }
 
 void pin_mode(PinName pin, PinMode mode)

--- a/source/port_api.c
+++ b/source/port_api.c
@@ -19,6 +19,7 @@
 
 PinName port_pin(PortName port, int pin_n)
 {
+    (void) port;
     return (PinName)(pin_n);
 }
 

--- a/source/pwmout_api.c
+++ b/source/pwmout_api.c
@@ -295,6 +295,7 @@ void pwmout_period_ms(pwmout_t *obj, int ms)
 // Set the PWM period, keeping the duty cycle the same.
 void pwmout_period_us(pwmout_t *obj, int us)
 {
+    (void) obj; // Avoid compiler warnings
     uint32_t periodInTicks = us / TIMER_PRECISION;
 
     NRF_TIMER2->EVENTS_COMPARE[3] = 0;

--- a/source/serial_api.c
+++ b/source/serial_api.c
@@ -76,7 +76,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->uart->TXD = 0;
 
     obj->index = 0;
-    
+
     obj->uart->PSELRTS = RTS_PIN_NUMBER;
     obj->uart->PSELTXD = tx; //TX_PIN_NUMBER;
     obj->uart->PSELCTS = CTS_PIN_NUMBER;
@@ -121,6 +121,10 @@ void serial_baud(serial_t *obj, int baudrate)
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
 {
+    /* Avoid compiler warnings */
+    (void) data_bits;
+    (void) stop_bits;
+
     // 0: 1 stop bits, 1: 2 stop bits
     // int parity_enable, parity_select;
     switch (parity) {
@@ -295,4 +299,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 }
 
 void serial_clear(serial_t *obj) {
+    /* Avoid compiler warnings */
+    (void) obj;
 }

--- a/source/sleep.c
+++ b/source/sleep.c
@@ -15,7 +15,7 @@
  */
 #include "sleep_api.h"
 #include "cmsis.h"
-#include "mbed_interface.h"
+#include "mbed-drivers/mbed_interface.h"
 #include "nrf_soc.h"
 
 void mbed_enter_sleep(sleep_t *obj)

--- a/source/spi_api.c
+++ b/source/spi_api.c
@@ -32,7 +32,7 @@ extern volatile i2c_spi_peripheral_t i2c1_spi1_peripheral;
 
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk)
 {
-    SPIName spi;
+    SPIName spi = SPI_0; // Initialize to avoid compiler warnings
 
     if (i2c0_spi0_peripheral.usage == I2C_SPI_PERIPHERAL_FOR_SPI &&
             i2c0_spi0_peripheral.sda_mosi == (uint8_t)mosi &&
@@ -108,6 +108,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk)
 
 void spi_free(spi_t *obj)
 {
+    (void) obj; // Avoid compiler warnings
 }
 
 static inline void spi_disable(spi_t *obj)
@@ -216,6 +217,7 @@ int spi_slave_receive(spi_t *obj)
 
 int spi_slave_read(spi_t *obj)
 {
+    (void) obj; // Avoid compiler warnings
     return m_rx_buf[0];
 }
 


### PR DESCRIPTION
Clean up code to reduce "unused parameter" warnings. However, to avoid changing
the API a statement with `(void) var;` was added after the function definition.
Also cleared some warnings regarding possibly uninitialised values by
initialising on declaration
@rgrover @0xc0170 