### PR TITLE
Fixed bug in lp_ticker_get_overflows_counter

### DIFF
--- a/source/lp_ticker.c
+++ b/source/lp_ticker.c
@@ -42,7 +42,7 @@ void lp_ticker_set_interrupt(uint32_t now, uint32_t time)
 
 uint32_t lp_ticker_get_overflows_counter(void)
 {
-    return overflowCount;
+    return overflowCount >> 8;
 }
 
 uint32_t lp_ticker_get_compare_match(void)


### PR DESCRIPTION
The lower 8 bits of the overflow counter was counted twice - once in lp_ticker_read (extending the 24 bit RTC counter to 32 bit) and once in lp_ticker_get_overflows_counter.