### PR TITLE
Update nrf51-sdk dependency to ^2.0.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "mbed-hal": "^1.0.0",
     "cmsis-core": "^1.0.0",
-    "nrf51-sdk": "^1.0.0"
+    "nrf51-sdk": "^2.0.0"
   },
   "targetDependencies": {
     "bbcmicro": {


### PR DESCRIPTION
This is because the major version of the nrf51-sdk module was updated to 2.0.0 when it was upgraded to SDK 10.0.0.
@pan- @LiyouZhou @0xc0170