### PR TITLE
Fixes #49 - mbed hal dependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
     "mbed-hal-nrf51822-mcu"
   ],
   "dependencies": {
-    "mbed-hal": "^1.0.0",
+    "mbed-hal": "*",
     "cmsis-core": "^1.0.0",
     "nrf51-sdk": "^2.0.0"
   },


### PR DESCRIPTION
The mbed hal dependency should be `*` as mbed-hal is a parent with
version selector for this module. (mbed-hal -> mbed-hal-nordic -> this repo)

@pan-
