### PR TITLE
Fix crash when interrupt is more than 8.5 minutes in the future

### DIFF
--- a/source/us_ticker.c
+++ b/source/us_ticker.c
@@ -159,10 +159,12 @@ void RTC1_IRQHandler(void)
         NRF_RTC1->EVENTS_OVRFLW = 0;
         NRF_RTC1->EVTENCLR      = RTC_EVTEN_OVRFLW_Msk;
     }
-    if (NRF_RTC1->EVENTS_COMPARE[0] && us_ticker_callbackPending && ((int)(us_ticker_callbackTimestamp - rtc1_getCounter()) <= 0)) {
+    if (NRF_RTC1->EVENTS_COMPARE[0]) {
         NRF_RTC1->EVENTS_COMPARE[0] = 0;
         NRF_RTC1->EVTENCLR          = RTC_EVTEN_COMPARE0_Msk;
-        invokeCallback();
+        if (us_ticker_callbackPending && ((int)(us_ticker_callbackTimestamp - rtc1_getCounter()) <= 0)) {
+            invokeCallback();
+        }
     }
     if (NRF_RTC1->EVENTS_COMPARE[1]) {
         // Compare[1] used by lp ticker


### PR DESCRIPTION
Basically the last condition in the if can be false if you set an interrupt too far in the future (more than one 24-bit timer loop), and if that happens then the IRQ is never cleared and the handler loops.

Fixes bug #53. I think. There are no tests so it's hard to be sure.
